### PR TITLE
Bump version to 0.0.11 and fix PSI read action threading

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@ androidStudioPath = ADD FULL PATH HERE EXAMPLE: /Users/afasfdfasd/ ..... /Androi
 
 pluginGroup=com.mgm
 pluginName=ADBTools
-pluginVersion=0.0.10
+pluginVersion=0.0.11
 pluginSinceBuild = 233
-pluginUntilBuild = 253.*
+pluginUntilBuild = 261.*
 platformType = AI
-platformVersion = 2025.3.1
+platformVersion = 2026.1.1
 org.gradle.jvmargs=-Xmx8192m
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/kotlin/com/mgm/adbtools/AdbControllerImp.kt
+++ b/src/main/kotlin/com/mgm/adbtools/AdbControllerImp.kt
@@ -65,7 +65,6 @@ import java.util.concurrent.TimeUnit
 import javax.swing.JFileChooser
 import javax.swing.JOptionPane
 import javax.swing.SwingUtilities
-import kotlin.math.max
 
 
 class AdbControllerImp(private val project: Project, private var debugBridge: AndroidDebugBridge?, private var toolWindow: ToolWindow? = null) :
@@ -177,7 +176,7 @@ class AdbControllerImp(private val project: Project, private var debugBridge: An
         showClassPopup(
             "Activities",
             list,
-            activitiesList.map { it.trim().replace(ACTIVITY_KILLED, EMPTY).substringAfter(HYPHEN).psiClassByNameFromProjct(project) }
+            activitiesList.map { it.trim().replace(ACTIVITY_KILLED, EMPTY).substringAfter(HYPHEN).psiClassByNameFromProject(project) }
         )
     }
 
@@ -223,7 +222,7 @@ class AdbControllerImp(private val project: Project, private var debugBridge: An
             this.setItemChoosenCallback {
                 displayList.getOrNull(list.selectedIndex)?.second?.let { className ->
                     if (className.contains(DOT))
-                        className.psiClassByNameFromProjct(project)?.openIn(project)
+                        className.psiClassByNameFromProject(project)?.openIn(project)
                     else
                         className.psiClassByNameFromCache(project)?.openIn(project)
                 }
@@ -236,7 +235,7 @@ class AdbControllerImp(private val project: Project, private var debugBridge: An
         execute {
             val activity =
                 GetActivityCommand().execute(Any(), project, device) ?: throw Exception("No activities found")
-            activity.psiClassByNameFromProjct(project)?.openIn(project)
+            activity.psiClassByNameFromProject(project)?.openIn(project)
                 ?: throw Exception("class $activity  Not Found")
         }
     }

--- a/src/main/kotlin/com/mgm/adbtools/PsiClassHelper.kt
+++ b/src/main/kotlin/com/mgm/adbtools/PsiClassHelper.kt
@@ -2,6 +2,7 @@ package com.mgm.adbtools
 
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.application.runReadActionBlocking
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.search.GlobalSearchScope
@@ -12,15 +13,18 @@ fun PsiClass.openIn(project: Project) {
 }
 
 fun String.psiClassByNameFromCache(project: Project): PsiClass? {
-    return PsiShortNamesCache
-        .getInstance(project)
-        .getClassesByName(
-            this, GlobalSearchScope.allScope(project)
-        )
-        .firstOrNull()
-//        .firstOrNull { it is KtUltraLightClass }
+    return runReadActionBlocking {
+        PsiShortNamesCache
+            .getInstance(project)
+            .getClassesByName(
+                this, GlobalSearchScope.allScope(project)
+            )
+            .firstOrNull()
+    }
 }
 
-fun String.psiClassByNameFromProjct(project: Project): PsiClass? {
-    return JavaPsiFacade.getInstance(project).findClass(this, GlobalSearchScope.allScope(project))
+fun String.psiClassByNameFromProject(project: Project): PsiClass? {
+    return runReadActionBlocking {
+        JavaPsiFacade.getInstance(project).findClass(this, GlobalSearchScope.allScope(project))
+    }
 }


### PR DESCRIPTION
- Bump pluginVersion to 0.0.11
- Update target platform to 2026.1.1 (Android Studio Quail Canary 1)
- Extend pluginUntilBuild from 253.* to 261.* to support newer builds
- Wrap PsiShortNamesCache and JavaPsiFacade lookups in runReadActionBlocking to ensure PSI access happens on a read action, preventing potential threading violations in newer platform versions
- Fix typo in extension function name: psiClassByNameFromProjct -> psiClassByNameFromProject, and update all 3 call sites in AdbControllerImp accordingly
- Remove unused kotlin.math.max import from AdbControllerImp